### PR TITLE
Ensure Prisma client is generated on install/build

### DIFF
--- a/be/package.json
+++ b/be/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "node dist/index.js",
     "dev": "nodemon src/index.ts",
-    "build": "tsc",
+    "build": "prisma generate --schema=./src/prisma/schema.prisma && tsc",
+    "postinstall": "prisma generate --schema=./src/prisma/schema.prisma",
     "test": "jest",
     "lint": "eslint . --ext .ts",
     "format": "prettier --write \"src/**/*.ts\"",


### PR DESCRIPTION
### Motivation
- Generate the Prisma client during install and build so the runtime Prisma models (e.g. `Group`) are available in production and to prevent errors like `Cannot read properties of undefined (reading 'findMany')`.

### Description
- Update `be/package.json` to run `prisma generate --schema=./src/prisma/schema.prisma` as part of the `build` script and add a `postinstall` script to ensure the Prisma client is generated after install.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d28b1dde88325a9e2f3402c1106c3)